### PR TITLE
SCSSのコンパイルにDart Sassを利用するように変更

### DIFF
--- a/gulpfile.js/index.js
+++ b/gulpfile.js/index.js
@@ -6,6 +6,8 @@ const config = require('config');
 const log = require('fancy-log');
 const { dest, lastRun, parallel, series, src, watch } = require('gulp');
 const plugins = require('gulp-load-plugins')();
+const fibers = require('fibers');
+plugins.sass.compiler = require('sass');
 
 const cssGlobs = 'app/{modules,themes}/custom/**/css/**/*.css';
 const jsGlobs = 'app/{modules,themes}/custom/**/js/**/*.es6.js';
@@ -41,6 +43,7 @@ function buildScss() {
       }),
     )
     .pipe(plugins.sassGlob())
+    .pipe(plugins.sass({ fiber: fibers }))
     .pipe(plugins.sass(config.sass))
     .pipe(
       plugins.rename(path => {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "config": "^3.3.3",
     "eslint-config-drupal": "^5.0.2",
     "fancy-log": "^1.3.3",
+    "fibers": "^5.0.0",
     "gulp": "^4.0.2",
     "gulp-babel": "^8.0.0",
     "gulp-eslint": "^6.0.0",
@@ -22,6 +23,7 @@
     "gulp-sass": "^4.1.0",
     "gulp-sass-glob": "^1.1.0",
     "gulp-stylelint": "^13.0.0",
+    "sass": "^1.32.2",
     "stylelint": "^13.8.0",
     "stylelint-config-drupal": "^1.0.0",
     "stylelint-scss": "^3.18.0"
@@ -30,9 +32,5 @@
     "presets": [
       "@babel/preset-env"
     ]
-  },
-  "dependencies": {
-    "fibers": "^5.0.0",
-    "sass": "^1.32.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,5 +30,9 @@
     "presets": [
       "@babel/preset-env"
     ]
+  },
+  "dependencies": {
+    "fibers": "^5.0.0",
+    "sass": "^1.32.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1833,6 +1833,21 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
+"chokidar@>=2.0.0 <4.0.0", chokidar@^3.4.1:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.0.tgz#458a4816a415e9d3b3caa4faec2b96a6935a9e65"
+  integrity sha512-JgQM9JS92ZbFR4P90EvmzNpSGhpPBGBSj10PILeDyYFwp4h2/D9OM03wsJ4zW1fEp4ka2DGrnUeD7FuvQ2aZ2Q==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.5.0"
+  optionalDependencies:
+    fsevents "~2.3.1"
+
 chokidar@^2.0.0:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
@@ -1851,21 +1866,6 @@ chokidar@^2.0.0:
     upath "^1.1.1"
   optionalDependencies:
     fsevents "^1.2.7"
-
-chokidar@^3.4.1:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.0.tgz#458a4816a415e9d3b3caa4faec2b96a6935a9e65"
-  integrity sha512-JgQM9JS92ZbFR4P90EvmzNpSGhpPBGBSj10PILeDyYFwp4h2/D9OM03wsJ4zW1fEp4ka2DGrnUeD7FuvQ2aZ2Q==
-  dependencies:
-    anymatch "~3.1.1"
-    braces "~3.0.2"
-    glob-parent "~5.1.0"
-    is-binary-path "~2.1.0"
-    is-glob "~4.0.1"
-    normalize-path "~3.0.0"
-    readdirp "~3.5.0"
-  optionalDependencies:
-    fsevents "~2.3.1"
 
 class-utils@^0.3.5:
   version "0.3.6"
@@ -2331,6 +2331,11 @@ detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
   integrity sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=
+
+detect-libc@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
+  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 dev-ip@^1.0.1:
   version "1.0.1"
@@ -3083,6 +3088,13 @@ fastq@^1.6.0:
   integrity sha512-NL2Qc5L3iQEsyYzweq7qfgy5OtXCmGzGvhElGEd/SoFWEMOEczNh5s5ocaF01HDetxz+p8ecjNPA6cZxxIHmzA==
   dependencies:
     reusify "^1.0.4"
+
+fibers@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/fibers/-/fibers-5.0.0.tgz#3a60e0695b3ee5f6db94e62726716fa7a59acc41"
+  integrity sha512-UpGv/YAZp7mhKHxDvC1tColrroGRX90sSvh8RMZV9leo+e5+EkRVgCEZPlmXeo3BUNQTZxUaVdLskq1Q2FyCPg==
+  dependencies:
+    detect-libc "^1.0.3"
 
 figures@^3.0.0:
   version "3.2.0"
@@ -6564,6 +6576,13 @@ sass-graph@2.2.5:
     lodash "^4.0.0"
     scss-tokenizer "^0.2.3"
     yargs "^13.3.2"
+
+sass@^1.32.2:
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.32.2.tgz#66dc0250bc86c15d19ddee7135e93d0cf3d3257b"
+  integrity sha512-u1pUuzqwz3SAgvHSWp1k0mRhX82b2DdlVnP6UIetQPZtYbuJUDaPQhZE12jyjB7vYeOScfz9WPsZJB6Rpk7heA==
+  dependencies:
+    chokidar ">=2.0.0 <4.0.0"
 
 scss-tokenizer@^0.2.3:
   version "0.2.3"


### PR DESCRIPTION
[Lib Sass](https://sass-lang.com/blog/libsass-is-deprecated)が非推奨となった為、[Dart Sass](https://sass-lang.com/dart-sass)を利用するように変更しました。

## 確認方法

Dart Sassのみ利用可能な `@use` 文が使えることにより挙動を確認

- `app/modules/custom/xxx/scss` ディレクトリを生成.
  - 上記ディレクトリ内に `styles.scss` 及び `_variables.scss` を作成

- `_variables.scss` に以下を記載

```sass
$main-color: #fff;
$sub-color: #ccc;
```

- `styles.scss` に以下を記載

```sass
@use "variables";

div {
  background: variables.$main-color;
}
```

- `gulp build:scss` を実行し `app/modules/custom/xxx/css` に `style.css` が生成されることを確認